### PR TITLE
feat: add contact form spam prevention and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/kv": "^3.0.0",
-        "next": "15.2.4",
+        "next": "^15.2.8",
         "nodemailer": "^6.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -667,9 +667,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
-      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.8.tgz",
+      "integrity": "sha512-TaEsAki14R7BlgywA05t2PFYfwZiNlGUHyIQHVyloXX3y+Dm0HUITe5YwTkjtuOQuDhuuLotNEad4VtnmE11Uw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -683,9 +683,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
-      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.5.tgz",
+      "integrity": "sha512-4OimvVlFTbgzPdA0kh8A1ih6FN9pQkL4nPXGqemEYgk+e7eQhsst/p35siNNqA49eQA6bvKZ1ASsDtu9gtXuog==",
       "cpu": [
         "arm64"
       ],
@@ -699,9 +699,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.5.tgz",
+      "integrity": "sha512-ohzRaE9YbGt1ctE0um+UGYIDkkOxHV44kEcHzLqQigoRLaiMtZzGrA11AJh2Lu0lv51XeiY1ZkUvkThjkVNBMA==",
       "cpu": [
         "x64"
       ],
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.5.tgz",
+      "integrity": "sha512-FMSdxSUt5bVXqqOoZCc/Seg4LQep9w/fXTazr/EkpXW2Eu4IFI9FD7zBDlID8TJIybmvKk7mhd9s+2XWxz4flA==",
       "cpu": [
         "arm64"
       ],
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.5.tgz",
+      "integrity": "sha512-4ZNKmuEiW5hRKkGp2HWwZ+JrvK4DQLgf8YDaqtZyn7NYdl0cHfatvlnLFSWUayx9yFAUagIgRGRk8pFxS8Qniw==",
       "cpu": [
         "arm64"
       ],
@@ -747,9 +747,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.5.tgz",
+      "integrity": "sha512-bE6lHQ9GXIf3gCDE53u2pTl99RPZW5V1GLHSRMJ5l/oB/MT+cohu9uwnCK7QUph2xIOu2a6+27kL0REa/kqwZw==",
       "cpu": [
         "x64"
       ],
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.5.tgz",
+      "integrity": "sha512-y7EeQuSkQbTAkCEQnJXm1asRUuGSWAchGJ3c+Qtxh8LVjXleZast8Mn/rL7tZOm7o35QeIpIcid6ufG7EVTTcA==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.5.tgz",
+      "integrity": "sha512-gQMz0yA8/dskZM2Xyiq2FRShxSrsJNha40Ob/M2n2+JGRrZ0JwTVjLdvtN6vCxuq4ByhOd4a9qEf60hApNR2gQ==",
       "cpu": [
         "arm64"
       ],
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.5.tgz",
+      "integrity": "sha512-tBDNVUcI7U03+3oMvJ11zrtVin5p0NctiuKmTGyaTIEAVj9Q77xukLXGXRnWxKRIIdFG4OTA2rUVGZDYOwgmAA==",
       "cpu": [
         "x64"
       ],
@@ -4353,12 +4353,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
-      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.8.tgz",
+      "integrity": "sha512-pe2trLKZTdaCuvNER0S9Wp+SP2APf7SfFmyUP9/w1SFA2UqmW0u+IsxCKkiky3n6um7mryaQIlgiDnKrf1ZwIw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.4",
+        "@next/env": "15.2.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -4373,14 +4373,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.4",
-        "@next/swc-darwin-x64": "15.2.4",
-        "@next/swc-linux-arm64-gnu": "15.2.4",
-        "@next/swc-linux-arm64-musl": "15.2.4",
-        "@next/swc-linux-x64-gnu": "15.2.4",
-        "@next/swc-linux-x64-musl": "15.2.4",
-        "@next/swc-win32-arm64-msvc": "15.2.4",
-        "@next/swc-win32-x64-msvc": "15.2.4",
+        "@next/swc-darwin-arm64": "15.2.5",
+        "@next/swc-darwin-x64": "15.2.5",
+        "@next/swc-linux-arm64-gnu": "15.2.5",
+        "@next/swc-linux-arm64-musl": "15.2.5",
+        "@next/swc-linux-x64-gnu": "15.2.5",
+        "@next/swc-linux-x64-musl": "15.2.5",
+        "@next/swc-win32-arm64-msvc": "15.2.5",
+        "@next/swc-win32-x64-msvc": "15.2.5",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@vercel/kv": "^3.0.0",
-    "next": "15.2.4",
+    "next": "^15.2.8",
     "nodemailer": "^6.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/lib/validation/contact-form.ts
+++ b/src/lib/validation/contact-form.ts
@@ -1,0 +1,203 @@
+/**
+ * Contact form validation utilities
+ * Shared between client and server for consistent validation
+ */
+
+// ===== Error Messages (Spanish) =====
+export const VALIDATION_MESSAGES = {
+  name: {
+    required: 'El nombre es requerido',
+    min: 'El nombre debe tener al menos 2 caracteres',
+    max: 'El nombre es demasiado largo',
+    format: 'El nombre solo puede contener letras y espacios',
+    noUrl: 'El nombre no puede contener URLs',
+    fullName: 'Por favor, ingresa tu nombre completo',
+  },
+  email: {
+    required: 'El correo electrónico es requerido',
+    invalid: 'Correo electrónico inválido',
+  },
+  phone: {
+    required: 'El teléfono es requerido',
+    invalid: 'Ingresa un número mexicano válido (10 dígitos)',
+  },
+  message: {
+    required: 'El mensaje es requerido',
+    min: 'El mensaje debe tener al menos 10 caracteres',
+    max: 'El mensaje es demasiado largo (máximo 2000 caracteres)',
+    tooManyUrls: 'El mensaje contiene demasiados enlaces',
+  },
+} as const;
+
+// ===== Patterns =====
+export const PATTERNS = {
+  // Letters, spaces, accents, apostrophes, and hyphens (common in names)
+  name: /^[a-zA-ZáéíóúüñÁÉÍÓÚÜÑ\s''-]+$/,
+  // Common URL patterns to detect
+  url: /(https?:\/\/|www\.|\.com|\.net|\.org|\.mx|\.io|\.co|\.ru|\.cn)/i,
+  // Standard email pattern
+  email: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+} as const;
+
+// ===== Utility Functions =====
+
+/**
+ * Normalize phone number by removing all non-digit characters
+ */
+export function normalizePhone(phone: string): string {
+  return phone.replace(/\D/g, '');
+}
+
+/**
+ * Check if text contains URL patterns
+ */
+export function containsUrl(text: string): boolean {
+  return PATTERNS.url.test(text);
+}
+
+/**
+ * Count number of URLs in text
+ */
+export function countUrls(text: string): number {
+  return (text.match(/https?:\/\/|www\./gi) || []).length;
+}
+
+// ===== Validation Functions =====
+// Each returns null if valid, or an error message string if invalid
+
+/**
+ * Validate name field
+ * - Min 2 characters
+ * - Max 100 characters
+ * - Only letters, spaces, accents, apostrophes, hyphens
+ * - Must contain a space (full name)
+ * - No URLs
+ */
+export function validateName(name: string): string | null {
+  const trimmed = name.trim();
+
+  if (!trimmed) {
+    return VALIDATION_MESSAGES.name.required;
+  }
+
+  if (trimmed.length < 2) {
+    return VALIDATION_MESSAGES.name.min;
+  }
+
+  if (trimmed.length > 100) {
+    return VALIDATION_MESSAGES.name.max;
+  }
+
+  if (!PATTERNS.name.test(trimmed)) {
+    return VALIDATION_MESSAGES.name.format;
+  }
+
+  if (containsUrl(trimmed)) {
+    return VALIDATION_MESSAGES.name.noUrl;
+  }
+
+  if (!trimmed.includes(' ')) {
+    return VALIDATION_MESSAGES.name.fullName;
+  }
+
+  return null;
+}
+
+/**
+ * Validate email field
+ */
+export function validateEmail(email: string): string | null {
+  const trimmed = email.trim();
+
+  if (!trimmed) {
+    return VALIDATION_MESSAGES.email.required;
+  }
+
+  if (!PATTERNS.email.test(trimmed)) {
+    return VALIDATION_MESSAGES.email.invalid;
+  }
+
+  return null;
+}
+
+/**
+ * Validate Mexican phone number
+ * Accepts:
+ * - 10 digits (local format)
+ * - 12 digits starting with 52 (country code)
+ */
+export function validateMexicanPhone(phone: string): string | null {
+  const normalized = normalizePhone(phone);
+
+  if (!normalized) {
+    return VALIDATION_MESSAGES.phone.required;
+  }
+
+  // 10 digits without country code
+  if (normalized.length === 10) {
+    return null;
+  }
+
+  // 12 digits with country code 52
+  if (normalized.length === 12 && normalized.startsWith('52')) {
+    return null;
+  }
+
+  return VALIDATION_MESSAGES.phone.invalid;
+}
+
+/**
+ * Validate message field
+ * - Min 10 characters
+ * - Max 2000 characters
+ * - Max 2 URLs allowed
+ */
+export function validateMessage(message: string): string | null {
+  const trimmed = message.trim();
+
+  if (!trimmed) {
+    return VALIDATION_MESSAGES.message.required;
+  }
+
+  if (trimmed.length < 10) {
+    return VALIDATION_MESSAGES.message.min;
+  }
+
+  if (trimmed.length > 2000) {
+    return VALIDATION_MESSAGES.message.max;
+  }
+
+  if (countUrls(trimmed) > 2) {
+    return VALIDATION_MESSAGES.message.tooManyUrls;
+  }
+
+  return null;
+}
+
+/**
+ * Validate all required form fields
+ * Returns object with field names as keys and error messages as values
+ * Empty object means all fields are valid
+ */
+export function validateContactForm(data: {
+  name: string;
+  email: string;
+  phone: string;
+  message: string;
+}): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  const nameError = validateName(data.name);
+  if (nameError) errors.name = nameError;
+
+  const emailError = validateEmail(data.email);
+  if (emailError) errors.email = emailError;
+
+  const phoneError = validateMexicanPhone(data.phone);
+  if (phoneError) errors.phone = phoneError;
+
+  const messageError = validateMessage(data.message);
+  if (messageError) errors.message = messageError;
+
+  return errors;
+}


### PR DESCRIPTION
## Summary

- Add multi-layered spam protection to the contact form to reduce spam submissions (~10+ daily)
- Implement client-side validation with inline error messages in Spanish
- Add Mexican phone number validation (10 digits or +52 country code format)

### Spam Prevention Measures

| Measure | Description |
|---------|-------------|
| Enhanced Honeypots | 3 hidden fields using display:none, off-screen positioning, and zero dimensions |
| Mexican Phone | Only 10 digits or +52 + 10 digits accepted |
| Full Name Required | Name must contain a space |
| No URLs in Name | Blocks common spam patterns |
| Max 2 URLs in Message | Prevents link spam |
| Timing Detection | Forms submitted in <3s are silently rejected |
| Rate Limiting | 60s cooldown between submissions (client-side) |

### Files Changed

- `src/lib/validation/contact-form.ts` - **NEW** shared validation utilities
- `src/components/forms/ContactForm.tsx` - Client-side validation, honeypots, timing, rate limiting
- `src/app/api/contact/route.ts` - Enhanced Zod schema and server-side spam detection

## Test plan

- [ ] Submit form with valid data - should succeed
- [ ] Submit with single name (no space) - should show error
- [ ] Submit with URL in name field - should show error
- [ ] Submit with invalid phone (9 or 11 digits) - should show error
- [ ] Submit with 3+ URLs in message - should show error
- [ ] Verify honeypot fields are not visible
- [ ] Verify rate limiting shows countdown after successful submit
- [ ] Verify pre-filled forms from wedding calculator still work